### PR TITLE
Fix /train form submission failing with empty site code

### DIFF
--- a/webapp/main.go
+++ b/webapp/main.go
@@ -134,7 +134,17 @@ type apiError struct {
 }
 
 func (a *App) handleAPITrain(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
+	// ParseMultipartForm, not ParseForm: the browser posts a FormData body
+	// (app.js's wireTrainForm), which is multipart/form-data, not
+	// application/x-www-form-urlencoded -- ParseForm never reads multipart
+	// bodies at all, and calling it here would additionally block
+	// FormValue's own lazy multipart-parsing fallback later (it only
+	// triggers when r.Form is still nil). ParseMultipartForm handles both:
+	// it parses the multipart body directly, and falls back to ParseForm
+	// internally for a plain urlencoded body (returning ErrNotMultipart,
+	// which isn't a real failure -- r.Form is still populated correctly in
+	// that case, exactly as net/http's own FormValue implementation treats it).
+	if err := r.ParseMultipartForm(32 << 20); err != nil && err != http.ErrNotMultipart {
 		writeJSONError(w, http.StatusBadRequest, "could not parse form: "+err.Error())
 		return
 	}


### PR DESCRIPTION
handleAPITrain called r.ParseForm(), which only parses application/x-www-form-urlencoded bodies. The browser form posts a FormData object via fetch(), which the browser encodes as multipart/form-data -- ParseForm never reads that body, and calling it explicitly sets r.Form to non-nil (from the empty query string), which blocks FormValue()'s own automatic fallback to ParseMultipartForm (that fallback only fires when r.Form is still nil). Net effect: site_code (and horizons) always read as empty, even when the user entered a valid site code.

Switched to r.ParseMultipartForm(32 << 20), treating http.ErrNotMultipart as non-fatal since that method calls ParseForm() internally first for non-multipart bodies before returning that sentinel error -- so both the real browser's multipart submission and plain urlencoded submissions (e.g. curl -d) are handled correctly by the same call.

Verified with curl -F (real multipart, matching the browser) and curl -d (urlencoded) against a running instance; both now correctly report the submitted site code in validation errors instead of "".